### PR TITLE
Providing release binary for gitt.io support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-android/build/classes/
-android/build/generated/
-android/dist/
 android/documentation/
 android/example/
 android/libs/
@@ -11,3 +8,5 @@ android/.classpath
 #android/manifest
 #.settings/
 .directory
+pdf417plugin.jar
+android/build


### PR DESCRIPTION
People can't install the module with gittio unless the binary is included in the repo. Typically people leave a binary history, too, so specific versions can be pulled. see http://gitt.io/contributors
